### PR TITLE
Adapt to only select hearthstones from a pledged covenant

### DIFF
--- a/Data.lua
+++ b/Data.lua
@@ -26,10 +26,13 @@ addon.HEARTHSTONE_TOY_ID = {
     166747, -- Brewfest Reveler's Hearthstone
     168907, -- Holographic Digitalization Hearthstone
     172179, -- Eternal Traveler's Hearthstone
-    180290, -- Night Fae Hearthstone
-    182773, -- Necrolord Hearthstone
-    183716, -- Venthyr Sinstone
-    184353, -- Kyrian Hearthstone
+}
+
+addon.COVENANT_HEARTHSTONE_TOY_ID = {
+    [1] = 184353, -- Kyrian Hearthstone
+    [2] = 183716, -- Venthyr Sinstone
+    [3] = 180290, -- Night Fae Hearthstone
+    [4] = 182773, -- Necrolord Hearthstone
 }
 
 -- Spell ID numbers for hearthstone-equivalent spells.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,17 @@ The random selection will be made from one of the following toys:
 - [Greatfather Winter's Hearthstone](https://www.wowhead.com/item=162973/greatfather-winters-hearthstone)
 - [Headless Horseman's Hearthstone](https://www.wowhead.com/item=163045/headless-horsemans-hearthstone)
 - [Holographic Digitalization Hearthstone](https://www.wowhead.com/item=168907/holographic-digitalization-hearthstone)
-- [Kyrian Hearthstone](https://www.wowhead.com/item=184353/kyrian-hearthstone)
 - [Lunar Elder's Hearthstone](https://www.wowhead.com/item=165669/lunar-elders-hearthstone)
-- [Necrolord Hearthstone](https://www.wowhead.com/item=182773/necrolord-hearthstone)
-- [Night Fae Hearthstone](https://www.wowhead.com/item=180290/night-fae-hearthstone)
 - [Noble Gardener's Hearthstone](https://www.wowhead.com/item=165802/noble-gardeners-hearthstone)
 - [Peddlefeet's Lovely Hearthstone](https://www.wowhead.com/item=165670/peddlefeets-lovely-hearthstone)
 - [The Innkeeper's Daughter](https://www.wowhead.com/item=64488/the-innkeepers-daughter)
+
+In addition, if the player is pledged to one of the Shadowlands Covenants, the
+covenant hearthstone toy (if owned) will be added to the set of toys to choose from:
+
+- [Kyrian Hearthstone](https://www.wowhead.com/item=184353/kyrian-hearthstone)
+- [Necrolord Hearthstone](https://www.wowhead.com/item=182773/necrolord-hearthstone)
+- [Night Fae Hearthstone](https://www.wowhead.com/item=180290/night-fae-hearthstone)
 - [Venthyr Sinstone](https://www.wowhead.com/item=183716/venthyr-sinstone-wip)
 
 If any of the above toys are marked as favorites, the random selection will be


### PR DESCRIPTION
In 9.0.5, Blizzard changed the covenant hearthstone toys to require that
you be pledged to that covenant.  The Necrolord one was apparently always
configured this way, so the addon was incorrectly selecting it for other
covenant members who had it in their toybox, producing a "you must be
pledged to the Necrolords" error, but now this is happening for all
four of the covanent toys.

Ref: https://www.wowhead.com/news/covenant-hearthstone-toys-can-only-be-used-by-players-of-that-covenant-321415