### PR TITLE
Add support for using hearthstone toys from other covenants, as long …

### DIFF
--- a/Addon.lua
+++ b/Addon.lua
@@ -167,12 +167,37 @@ function addon:_UpdateToys()
     for _, toyId in pairs(self.HEARTHSTONE_TOY_ID) do
         hasFavorites = self:_MaybeAddToy(toyId, hasFavorites)
     end
-    local covenantId = GetActiveCovenantID()
-    if covenantId ~= 0 then
-        local toyId = self.COVENANT_HEARTHSTONE_TOY_ID[covenantId]
-        self:_MaybeAddToy(toyId, hasFavorites)
+
+	-- Current covenant's toy is always usable by this character
+	local covenantId = GetActiveCovenantID()
+	if covenantId ~= 0 then
+		local toyId = self.COVENANT_HEARTHSTONE_TOY_ID[covenantId]
+		self:_MaybeAddToy(toyId, hasFavorites)
+	end
+	
+	-- Toys from other covenants are only usable if a character on this account has
+	-- reached renown 80 with that covenant.
+	if self:_HasObtainedAchivement(self.KYRIAN_RENOWN_80_ACHIVEMENT) then
+		self:_MaybeAddToy(self.COVENANT_HEARTHSTONE_TOY_ID[1], hasFavorites)
+    end
+	
+	if self:_HasObtainedAchivement(self.VENTHYR_RENOWN_80_ACHIVEMENT) then
+		self:_MaybeAddToy(self.COVENANT_HEARTHSTONE_TOY_ID[2], hasFavorites)
+    end
+
+	if self:_HasObtainedAchivement(self.NIGHTFAE_RENOWN_80_ACHIVEMENT) then
+		self:_MaybeAddToy(self.COVENANT_HEARTHSTONE_TOY_ID[3], hasFavorites)
+    end
+
+	if self:_HasObtainedAchivement(self.NECROLORDS_RENOWN_80_ACHIVEMENT) then
+		self:_MaybeAddToy(self.COVENANT_HEARTHSTONE_TOY_ID[4], hasFavorites)
     end
 end
+
+function addon:_HasObtainedAchivement(achievementId)
+  local id, name, points, completed, month, day, year, description, flags, image, rewardtext, isGuild = GetAchievementInfo(achievementId)
+  return completed
+end  
 
 function addon:_MaybeAddToy(toyId, hasFavorites)
     if PlayerHasToy(toyId) then

--- a/Data.lua
+++ b/Data.lua
@@ -4,6 +4,13 @@ local addonName, addon = ...
 addon.MACRO_ICON_PATH = "Interface/icons/achievement_guildperk_hastyhearth.blp"
 addon.MACRO_ICON_ID = GetFileIDFromPath(addon.MACRO_ICON_PATH)
 
+-- Achiemvent IDs for reaching renown 80 with a given covenant.  
+-- Once obtained, cosmetics from this covenant are unlocked account-wide.
+addon.KYRIAN_RENOWN_80_ACHIVEMENT = 15242
+addon.NECROLORDS_RENOWN_80_ACHIVEMENT = 15243
+addon.NIGHTFAE_RENOWN_80_ACHIVEMENT = 15244
+addon.VENTHYR_RENOWN_80_ACHIVEMENT = 15245
+
 -- Item ID numbers for the hearthstone and hearthstone-equivalent items.
 addon.HEARTHSTONE_ITEM_ID = {
 	6948, -- Hearthstone

--- a/HearthRoulette.toc
+++ b/HearthRoulette.toc
@@ -5,8 +5,8 @@
 ## X-Category: Miscellaneous
 ## X-Localizations: enUS
 
-## Interface: 90100
-## Version: @project-version@
+## Interface: 90205
+## Version: v6
 
 ## Author: Hascat
 ## X-Author-Server: US-Cairne

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ The random selection will be made from one of the following toys:
 - [Noble Gardener's Hearthstone](https://www.wowhead.com/item=165802/noble-gardeners-hearthstone)
 - [Peddlefeet's Lovely Hearthstone](https://www.wowhead.com/item=165670/peddlefeets-lovely-hearthstone)
 - [The Innkeeper's Daughter](https://www.wowhead.com/item=64488/the-innkeepers-daughter)
+- [Tome of Town Portal](https://www.wowhead.com/item=142542/tome-of-town-portal)
+- [Eternal Traveler's Hearthstone](https://www.wowhead.com/item=172179/eternal-travelers-hearthstone)
+- [Dominated Hearthstone](https://www.wowhead.com/item=188952/dominated-hearthstone)
+- [Broker Translocation Matrix](https://www.wowhead.com/item=190237/broker-translocation-matrix)
+- [Timewalker's Hearthstone](https://www.wowhead.com/item=193588/timewalkers-hearthstone)
 
 In addition, if the player is pledged to one of the Shadowlands Covenants, the
 covenant hearthstone toy (if owned) will be added to the set of toys to choose from:
@@ -34,6 +39,10 @@ covenant hearthstone toy (if owned) will be added to the set of toys to choose f
 - [Necrolord Hearthstone](https://www.wowhead.com/item=182773/necrolord-hearthstone)
 - [Night Fae Hearthstone](https://www.wowhead.com/item=180290/night-fae-hearthstone)
 - [Venthyr Sinstone](https://www.wowhead.com/item=183716/venthyr-sinstone-wip)
+
+If the player has unlocked Renown 80 with a covenant, that covenant's hearthstone 
+will be usable by any character regardless of current covenant, and so that toy will
+be added to the set of toys to choose from.
 
 If any of the above toys are marked as favorites, the random selection will be
 made only from those toys marked as favorites.


### PR DESCRIPTION
…as the account has unlocked renown 80 with that covenant.  Update readme with missing links, bump TOC interface to 9.2.5.