### PR TITLE
Data: Add Explosive Hearthstone added in patch 11.1.0

### DIFF
--- a/Data.lua
+++ b/Data.lua
@@ -36,6 +36,7 @@ addon.HEARTHSTONE_TOY_ID = {
     209035, -- Hearthstone of the Flame
     212337, -- Stone of the Hearth
     228940, -- Notorious Thread's Hearthstone
+    236687, -- Explosive Hearthstone
 }
 
 addon.COVENANT_HEARTHSTONE_TOY_ID = {


### PR DESCRIPTION
Adds the item ID for the "Explosive Hearthstone" that drops from Stix Bunkjunker boss in the Undermine raid.

Fixes https://github.com/hascat/HearthRoulette/issues/40.